### PR TITLE
Fixed: Not working when root files don't exist.

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@ var program = require('commander');
 // The functionalities
 var functions = require('./lib/functions.js');
 
+functions.checkFiles();
+
 program
     .version('1.0.0');
 

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -86,3 +86,14 @@ module.exports.copySnippet = function (snippetName) {
     // Copy the text to clipboard
     require('copy-paste').copy(text, function() { process.exit(0); });
 };
+
+
+module.exports.checkFiles = function() {
+    try {
+        fs.mkdirSync(snippetsRoot);
+        fs.writeFileSync(snippetsIndex, '[]');
+    }
+    catch(e) {
+        if ( e.code != 'EEXIST' ) throw e;
+    }
+}


### PR DESCRIPTION
Creates the .snips directory and .snipsIndex file (with empty JSON) if they don't exist.
