### PR TITLE
Allow editing of existing snips.

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ program
 program
     .command('edit [snippet-name]')
     .description('Edit an existing code snippet')
-    .action(functions.createSnippet);
+    .action(functions.editSnippet);
 
 program
     .command('list')

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -60,30 +60,27 @@ module.exports.editSnippet = function (snippetName) {
     // Generate fileName
     var fileName = path.join(snippetsRoot, snippetName);
 
-    // Open up vim for creating the snippet and then wait for close
+    // Open up vim with the given snippet's contents and then wait for close
     var editor = require('child_process').spawn(process.env.EDITOR, [fileName], {stdio: 'inherit'});
 
-    // When the editor exits, we extract the yaml-front-matter and save it elsewhere
+    // When the editor exits, we simply update the given file
     editor.on('exit', function () {
         fs.readFile(fileName, 'utf8', function (err, data) {
             if (err) {
-                // In case we fail, we delete the file
+                // In case we fail, we return with code 1
                 helper.error('Filesystem error');
-                shell.rm(fileName);
                 process.exit(1);
             }
 
-            // Process the yaml frontmatter
+            // Process the updated file
             var content = require('front-matter')(data);
             var body = content.body;
-            var metadata = { 'tags': content.attributes.tags, 'language': content.attributes.language};
 
             // Write the contents to the file
             fs.writeFile(fileName, body, function() {
                 if (err) {
-                    // In case we fail, we delete the file
+                    // In case we fail, we return with code 1
                     helper.error('Filesystem error');
-                    shell.rm(fileName);
                     process.exit(1);
                 }
             });

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -55,6 +55,43 @@ module.exports.createSnippet = function (snippetName) {
     });
 };
 
+// Function to edit a snippet with the given name
+module.exports.editSnippet = function (snippetName) {
+    // Generate fileName
+    var fileName = path.join(snippetsRoot, snippetName);
+
+    // Open up vim for creating the snippet and then wait for close
+    var editor = require('child_process').spawn(process.env.EDITOR, [fileName], {stdio: 'inherit'});
+
+    // When the editor exits, we extract the yaml-front-matter and save it elsewhere
+    editor.on('exit', function () {
+        fs.readFile(fileName, 'utf8', function (err, data) {
+            if (err) {
+                // In case we fail, we delete the file
+                helper.error('Filesystem error');
+                shell.rm(fileName);
+                process.exit(1);
+            }
+
+            // Process the yaml frontmatter
+            var content = require('front-matter')(data);
+            var body = content.body;
+            var metadata = { 'tags': content.attributes.tags, 'language': content.attributes.language};
+
+            // Write the contents to the file
+            fs.writeFile(fileName, body, function() {
+                if (err) {
+                    // In case we fail, we delete the file
+                    helper.error('Filesystem error');
+                    shell.rm(fileName);
+                    process.exit(1);
+                }
+            });
+        });
+    });
+};
+
+
 // Function to list snippets from the snips directory
 module.exports.listSnippets = function() {
     fs.readdir(snippetsRoot, function (err, items) {


### PR DESCRIPTION
A simple hack to get the `edit` endpoint working, goes exactly as the `create` endpoint works, but doesn't write the standard template to the file yet.
Perhaps to avoid redundancy, the common code in these methods should be kept in a separate function called by both of them but with a bool flag whether to write/over-write the file or not.
Doesn't handle editing the tags at all yet. I could not get the yaml-frontmatter to write the tags I wrote to .snippetsIndex
